### PR TITLE
倍率の修正

### DIFF
--- a/components/page.tsx
+++ b/components/page.tsx
@@ -17,6 +17,7 @@ export const Main = styled.main`
   align-items: center;
   justify-content: center;
   padding: 5rem 0;
+  zoom: 27%;
 `
 export const Footer = styled.footer`
   display: flex;


### PR DESCRIPTION
全体の倍率を下げて、ブロックが拡大されて表示される箇所を修正しました。
ブラウザの倍率を１００％として表示した場合がこちらです。
![2022-01-28-09-48-48](https://user-images.githubusercontent.com/43735224/151467666-5c999300-6e29-4dd5-a2f7-24d71d46da6a.png)

