### PR TITLE
ブロックサイズの固定

### DIFF
--- a/components/boardOrigin.tsx
+++ b/components/boardOrigin.tsx
@@ -1,18 +1,13 @@
 import React from 'react'
-import styled from 'styled-components'
 import { BoardOriginProps } from '../types/board/origin'
 import type { ClickBlockAction } from '../types/board/util'
-import type { BoardZoomProps, Pos, Values } from '../types/type'
+import type { Pos, Values } from '../types/type'
 import { calBom, resetBoms } from '../utils/bom'
 import { posArrayEquall, posEquall } from '../utils/position'
 import { updatePosition } from '../utils/updatePosition'
 import { BoardHead } from './boardHead'
 import { BoardContent } from './boardMain'
 import { BoardFrame } from './boardStyle'
-
-const StyledDiv = styled.div<BoardZoomProps>`
-  zoom: ${(props) => props.zoom};
-`
 
 export const BoardOrigin: React.FC<BoardOriginProps> = ({ parentStates, funs }) => {
   const {
@@ -110,17 +105,10 @@ export const BoardOrigin: React.FC<BoardOriginProps> = ({ parentStates, funs }) 
     sizey: boardSize.sizeY,
   }
 
-  const sizeXnorm = boardSize.sizeX / (boardSize.sizeX + 1)
-  const sizeYnorm = boardSize.sizeY / (boardSize.sizeY + 1)
-  const boardZoomX = 40 * (1 - 0.994 * sizeXnorm)
-  const boardZoomY = 40 * (1 - 0.994 * sizeYnorm)
-  const boardZoom = Math.min(boardZoomX, boardZoomY)
   return (
-    <StyledDiv zoom={boardZoom}>
-      <BoardFrame boardsize={tmpBoardSize}>
-        <BoardHead states={parentStates} funs={{ refreshState }} />
-        <BoardContent states={parentStates} funs={{ onClick, onContextMenu }} />
-      </BoardFrame>
-    </StyledDiv>
+    <BoardFrame boardsize={tmpBoardSize}>
+      <BoardHead states={parentStates} funs={{ refreshState }} />
+      <BoardContent states={parentStates} funs={{ onClick, onContextMenu }} />
+    </BoardFrame>
   )
 }

--- a/components/boardStyle.tsx
+++ b/components/boardStyle.tsx
@@ -40,8 +40,6 @@ export const BoardHeader = styled.div<BoardSizeProps>`
 BoardHeader.defaultProps = defaultBoardSize
 
 export const BoardFrame = styled.div<BoardSizeProps>`
-  transform-origin: top left;
-  transform: scale(0.8);
   width: ${(props) => 55 + props.boardsize.sizex * 50}px;
   height: ${(props) => 160 + props.boardsize.sizey * 50}px;
   background-color: #d4d4d4;

--- a/components/boardStyle.tsx
+++ b/components/boardStyle.tsx
@@ -40,6 +40,8 @@ export const BoardHeader = styled.div<BoardSizeProps>`
 BoardHeader.defaultProps = defaultBoardSize
 
 export const BoardFrame = styled.div<BoardSizeProps>`
+  transform-origin: top left;
+  transform: scale(0.9);
   width: ${(props) => 55 + props.boardsize.sizex * 50}px;
   height: ${(props) => 160 + props.boardsize.sizey * 50}px;
   background-color: #d4d4d4;

--- a/components/boardStyle.tsx
+++ b/components/boardStyle.tsx
@@ -41,7 +41,7 @@ BoardHeader.defaultProps = defaultBoardSize
 
 export const BoardFrame = styled.div<BoardSizeProps>`
   transform-origin: top left;
-  transform: scale(0.9);
+  transform: scale(0.8);
   width: ${(props) => 55 + props.boardsize.sizex * 50}px;
   height: ${(props) => 160 + props.boardsize.sizey * 50}px;
   background-color: #d4d4d4;

--- a/components/difficultyButton.tsx
+++ b/components/difficultyButton.tsx
@@ -4,7 +4,7 @@ import { DifficultyButtonProps } from '../types/difficultySelector/difficultyBut
 
 const MyButton = styled.button`
   margin-right: 1em;
-  font-size: 24px;
+  font-size: 26px;
   font-weight: bold;
   color: black;
   cursor: pointer;

--- a/components/difficultyButton.tsx
+++ b/components/difficultyButton.tsx
@@ -3,8 +3,9 @@ import styled from 'styled-components'
 import { DifficultyButtonProps } from '../types/difficultySelector/difficultyButton'
 
 const MyButton = styled.button`
-  margin-right: 1em;
+  margin-right: 25px;
   font-size: 26px;
+  padding: 0;
   font-weight: bold;
   color: black;
   cursor: pointer;

--- a/components/difficultyButton.tsx
+++ b/components/difficultyButton.tsx
@@ -3,9 +3,9 @@ import styled from 'styled-components'
 import { DifficultyButtonProps } from '../types/difficultySelector/difficultyButton'
 
 const MyButton = styled.button`
+  padding: 0;
   margin-right: 25px;
   font-size: 26px;
-  padding: 0;
   font-weight: bold;
   color: black;
   cursor: pointer;

--- a/components/difficultySelector.tsx
+++ b/components/difficultySelector.tsx
@@ -16,7 +16,9 @@ const DifficultySelectorDiv = styled.div`
   display: flex;
   flex-direction: column;
 `
-const DifficultyButtonDiv = styled.div``
+const DifficultyButtonDiv = styled.div`
+  padding-bottom: 0.5em;
+`
 
 export const DifficultySelector: React.FC<DifficultySelectorProps> = ({ states, funs }) => {
   const [specialFirstState, setSpecialFirstState] =

--- a/components/difficultySelector.tsx
+++ b/components/difficultySelector.tsx
@@ -12,8 +12,11 @@ import { DifficultyButton } from './difficultyButton'
 import { SpecialForm } from './specialForm'
 
 const DifficultySelectorDiv = styled.div`
-  margin-left: 0.5em;
+  padding: 0 1em;
+  display: flex;
+  flex-direction: column;
 `
+const DifficultyButtonDiv = styled.div``
 
 export const DifficultySelector: React.FC<DifficultySelectorProps> = ({ states, funs }) => {
   const [specialFirstState, setSpecialFirstState] =
@@ -42,18 +45,22 @@ export const DifficultySelector: React.FC<DifficultySelectorProps> = ({ states, 
 
   return isActive.special ? (
     <DifficultySelectorDiv>
-      <DifficultyButton funs={{ refreshStateWithDifficulty }} consts={consts.easy} />
-      <DifficultyButton funs={{ refreshStateWithDifficulty }} consts={consts.middle} />
-      <DifficultyButton funs={{ refreshStateWithDifficulty }} consts={consts.difficult} />
-      <DifficultyButton funs={{ refreshStateWithDifficulty }} consts={consts.special} />
+      <DifficultyButtonDiv>
+        <DifficultyButton funs={{ refreshStateWithDifficulty }} consts={consts.easy} />
+        <DifficultyButton funs={{ refreshStateWithDifficulty }} consts={consts.middle} />
+        <DifficultyButton funs={{ refreshStateWithDifficulty }} consts={consts.difficult} />
+        <DifficultyButton funs={{ refreshStateWithDifficulty }} consts={consts.special} />
+      </DifficultyButtonDiv>
       <SpecialForm funs={{ refreshStateWithDifficulty, setSpecialFirstState }} />
     </DifficultySelectorDiv>
   ) : (
     <DifficultySelectorDiv>
-      <DifficultyButton funs={{ refreshStateWithDifficulty }} consts={consts.easy} />
-      <DifficultyButton funs={{ refreshStateWithDifficulty }} consts={consts.middle} />
-      <DifficultyButton funs={{ refreshStateWithDifficulty }} consts={consts.difficult} />
-      <DifficultyButton funs={{ refreshStateWithDifficulty }} consts={consts.special} />
+      <DifficultyButtonDiv>
+        <DifficultyButton funs={{ refreshStateWithDifficulty }} consts={consts.easy} />
+        <DifficultyButton funs={{ refreshStateWithDifficulty }} consts={consts.middle} />
+        <DifficultyButton funs={{ refreshStateWithDifficulty }} consts={consts.difficult} />
+        <DifficultyButton funs={{ refreshStateWithDifficulty }} consts={consts.special} />
+      </DifficultyButtonDiv>
     </DifficultySelectorDiv>
   )
 }

--- a/components/difficultySelector.tsx
+++ b/components/difficultySelector.tsx
@@ -12,9 +12,7 @@ import { DifficultyButton } from './difficultyButton'
 import { SpecialForm } from './specialForm'
 
 const DifficultySelectorDiv = styled.div`
-  margin: 0 auto;
-  margin-left: 1em;
-  zoom: 3;
+  margin-left: 0.5em;
 `
 
 export const DifficultySelector: React.FC<DifficultySelectorProps> = ({ states, funs }) => {

--- a/components/difficultySelector.tsx
+++ b/components/difficultySelector.tsx
@@ -12,9 +12,9 @@ import { DifficultyButton } from './difficultyButton'
 import { SpecialForm } from './specialForm'
 
 const DifficultySelectorDiv = styled.div`
-  padding: 0 1em;
   display: flex;
   flex-direction: column;
+  padding: 0 1em;
 `
 const DifficultyButtonDiv = styled.div`
   padding-bottom: 0.25em;

--- a/components/difficultySelector.tsx
+++ b/components/difficultySelector.tsx
@@ -17,7 +17,7 @@ const DifficultySelectorDiv = styled.div`
   flex-direction: column;
 `
 const DifficultyButtonDiv = styled.div`
-  padding-bottom: 0.5em;
+  padding-bottom: 0.25em;
 `
 
 export const DifficultySelector: React.FC<DifficultySelectorProps> = ({ states, funs }) => {

--- a/components/page.tsx
+++ b/components/page.tsx
@@ -1,40 +1,12 @@
 import styled from 'styled-components'
 
 export const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
   height: 100vh;
   min-height: 100vh;
   padding: 0 0.5rem;
+  display: flex;
 `
 
 export const Main = styled.main`
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
   padding: 5rem 0;
-  zoom: 27%;
-`
-export const Footer = styled.footer`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  height: 100px;
-  border-top: 1px solid #eaeaea;
-
-  a {
-    display: flex;
-    flex-grow: 1;
-    align-items: center;
-    justify-content: center;
-  }
-`
-export const Logo = styled.span`
-  height: 1em;
-  margin-left: 0.5rem;
 `

--- a/components/page.tsx
+++ b/components/page.tsx
@@ -1,10 +1,12 @@
 import styled from 'styled-components'
 
 export const Container = styled.div`
-  height: 100vh;
-  min-height: 100vh;
   padding: 0 0.5rem;
+  transform-origin: top center;
+  transform: scale(0.7);
+
   display: flex;
+  justify-content: center;
 `
 
 export const Main = styled.main`

--- a/components/page.tsx
+++ b/components/page.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components'
 
 export const Container = styled.div`
-
   display: flex;
   justify-content: center;
   padding: 0 0.5rem;

--- a/components/page.tsx
+++ b/components/page.tsx
@@ -1,12 +1,12 @@
 import styled from 'styled-components'
 
 export const Container = styled.div`
-  padding: 0 0.5rem;
-  transform-origin: top center;
-  transform: scale(0.7);
 
   display: flex;
   justify-content: center;
+  padding: 0 0.5rem;
+  transform: scale(0.7);
+  transform-origin: top center;
 `
 
 export const Main = styled.main`

--- a/components/specialForm.tsx
+++ b/components/specialForm.tsx
@@ -26,7 +26,7 @@ const StyledLabel = styled.label`
   font-weight: bold;
 `
 const StyledDiv = styled.div`
-  padding-left: 0.5em;
+  padding-bottom: 0.5em;
 `
 
 export const SpecialForm: React.FC<SpecialFormProps> = ({ funs }) => {

--- a/components/specialForm.tsx
+++ b/components/specialForm.tsx
@@ -26,7 +26,7 @@ const StyledLabel = styled.label`
   font-weight: bold;
 `
 const StyledDiv = styled.div`
-  padding-bottom: 0.5em;
+  padding-bottom: 0.25em;
 `
 
 export const SpecialForm: React.FC<SpecialFormProps> = ({ funs }) => {

--- a/components/specialForm.tsx
+++ b/components/specialForm.tsx
@@ -7,7 +7,7 @@ import { FIRST_STATE_SPECIAL } from '../utils/firstState'
 const StyledInput = styled.input`
   width: 4em;
   margin-right: 1em;
-  font-size: 20px;
+  font-size: 24px;
   border: 2px solid #ddd;
 `
 const StyledButton = styled.button`
@@ -22,11 +22,11 @@ const StyledButton = styled.button`
 `
 
 const StyledLabel = styled.label`
-  font-size: 20px;
+  font-size: 24px;
   font-weight: bold;
 `
 const StyledDiv = styled.div`
-  margin-left: 0.5em;
+  padding-left: 0.5em;
 `
 
 export const SpecialForm: React.FC<SpecialFormProps> = ({ funs }) => {

--- a/types/type.ts
+++ b/types/type.ts
@@ -9,10 +9,6 @@ export type BoardSizeProps = {
   }
 }
 
-export type BoardZoomProps = {
-  zoom: number
-}
-
 export type DifficultyFirstStates = {
   difficulty: string
   bomNum: number


### PR DESCRIPTION
ブロック数が多くなった場合にも盤面全体を表示することとブロックサイズを固定することは両立させることは不可能であったため、スペシャルでは一部が見切れる形としてブロックサイズを固定する形で修正しました。
（[https://minesweeper.online/](https://minesweeper.online/)でも見切れていたため、仕方ないことなのかと思います。）

わかりにくいと思いますが、ブロックサイズは全て一緒です。
初級
![2022-02-04-15-52-29](https://user-images.githubusercontent.com/43735224/152485219-a189a729-0ae1-49ab-bd13-ce93b469cef0.png)
中級
![2022-02-04-15-52-40](https://user-images.githubusercontent.com/43735224/152485212-c3f1aa7d-d6c9-4980-b012-a43d3f15087e.png)
上級
![2022-02-04-15-52-47](https://user-images.githubusercontent.com/43735224/152485217-225a661f-3961-414b-a4b6-e1023344e097.png)
スペシャル
![2022-02-04-15-52-53](https://user-images.githubusercontent.com/43735224/152485218-2db81be0-b2a7-4a28-93c8-262defea1b7e.png)

